### PR TITLE
Minor syntax clean up

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,6 @@
 * [Usage](#usage)
 * [Testing](#testing)
 * [Credits](#credits)
-* [Todo](#todo)
 
 This package hashes the primary key of an eloquent record.
 

--- a/src/Traits/Hashid.php
+++ b/src/Traits/Hashid.php
@@ -11,6 +11,7 @@ trait Hashid
      * Encode hashed id.
      *
      * @return mixed
+     *
      * @throws \Exception
      */
     public function getHashedIdAttribute()
@@ -25,6 +26,7 @@ trait Hashid
      *
      * @param $id
      * @return |null
+     *
      * @throws \Exception
      */
     public static function DecodeId($id)

--- a/src/Traits/Hashid.php
+++ b/src/Traits/Hashid.php
@@ -42,7 +42,7 @@ trait Hashid
             throw new ModelNotFoundException('Unable to find element', 404);
         }
 
-        return $query->findOrFail(self::DecodeId($id));
+        return $query->findOrFail($decoded);
     }
 
     public function scopeFindHashed($query, $id)
@@ -51,7 +51,7 @@ trait Hashid
             return;
         }
 
-        return $query->find(self::DecodeId($id));
+        return $query->find($decoded);
     }
 
     public function scopeWhereInHashed($query, $values)


### PR DESCRIPTION
- Remove inactive `Todo` link from `readme.md` file.
- use already defined `$decoded` variable to avoid redundant call for `self::DecodeId($id)` in `Erashdan\Hashid\Traits\Hashid`.